### PR TITLE
Improve chart loading

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -493,6 +493,7 @@
   },
   "chart": {
     "dataMissing": "We are still gathering information. Please try again in a few minutes.",
+    "dataUpdating": "updating data…",
     "filter": {
       "all": "All",
       "month": "Month",

--- a/frontends/web/src/routes/account/summary/accountssummary.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.css
@@ -46,6 +46,7 @@
 .table tr td,
 .table tfoot th {
     font-size: var(--size-default) !important;
+    line-height: 1.5714;
 }
 
 .table tbody td {

--- a/frontends/web/src/routes/account/summary/chart.css
+++ b/frontends/web/src/routes/account/summary/chart.css
@@ -3,6 +3,14 @@
   margin-bottom: var(--spacing-large);
 }
 
+.chartCanvas {
+  position: relative;
+}
+
+.chartUpdatignMessage {
+  text-align: center;
+}
+
 .invisible {
   visibility: hidden;
 }


### PR DESCRIPTION
- use apiGet directly and remove load decorator
- pull account-summary fast if there is no data or chartDataMissing
- minor visual text alignment changes, loading text and summary table
- create chart later in component live cycle once chart data is available
- update chart line series if chart data length changed
- prevent error during initial loading (block sync)
- show update data text if isUpToDate is false