### PR TITLE
frontend: update address type switch

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -70,7 +70,7 @@ export const getStatus = (code: AccountCode): Promise<IStatus> => {
     return apiGet(`account/${code}/status`);
 };
 
-export type ScriptType = 'p2pkh' | 'p2wpkh-p2sh' | 'p2wpkh';
+export type ScriptType = 'p2pkh' | 'p2wpkh-p2sh' | 'p2wpkh' | 'p2tr';
 
 export interface IKeyInfo {
     keypath: string;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1091,6 +1091,11 @@
       "description": "To receive other tokens, enable them in the settings. If you deposit other tokens, they might not be accessible.",
       "warning": "Make sure to only receive {{coinName}} on this address."
     },
+    "scriptType": {
+      "p2tr": "change to modern address (taproot)",
+      "p2wpkh": "change back to standard address (recommended)",
+      "p2wpkh-p2sh": "change to compatible address (Segwit)"
+    },
     "showFull": "Show and verify full address on device",
     "title": "Get {{accountName}}",
     "verify": "Verify address securely",

--- a/frontends/web/src/routes/account/receive/receive.module.css
+++ b/frontends/web/src/routes/account/receive/receive.module.css
@@ -56,8 +56,13 @@
 }
 
 .changeType {
+    appearance: none;
+    background: none;
+    border: none;
     color: var(--color-secondary);
     cursor: pointer;
+    display: inline-block;
     text-align: center;
     text-decoration: underline;
+    padding: var(--space-quarter);
 }

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -162,11 +162,15 @@ class Receive extends Component<Props, State> {
         return this.props.devices[this.props.deviceIDs[0]];
     }
 
-    private switchToScriptType = (scriptType: accountApi.ScriptType) => {
-        this.setState({
-            addressType: this.props.receiveAddresses.findIndex(addrs => addrs.scriptType! === scriptType),
+    private nextAddressType = () => {
+        this.setState(({ addressType }) => ({
             activeIndex: 0,
-        });
+            addressType: this.getNextAddressTypeIndex(addressType)
+        }));
+    }
+
+    private getNextAddressTypeIndex = (currentAddressType: number) => {
+        return (currentAddressType + 1) % this.availableScriptTypes.length;
     }
 
     public render() {
@@ -246,13 +250,10 @@ class Receive extends Component<Props, State> {
                 </div>
                 <CopyableInput disabled={!enableCopy} value={address} flexibleHeight />
                 { this.availableScriptTypes.length > 1 && (
-                      this.availableScriptTypes.map(scriptType => (
-                          <p className={style.changeType} onClick={() => this.switchToScriptType(scriptType)}>
-                              {t(`receive.scriptType.${scriptType}`)}
-                              { scriptType === receiveAddresses[addressType].scriptType && ' (active)' }
-                          </p>
-                      ))
-                  )}
+                    <button className={style.changeType} onClick={this.nextAddressType}>
+                        {t(`receive.scriptType.${receiveAddresses[this.getNextAddressTypeIndex(addressType)].scriptType}`)}
+                    </button>
+                )}
                 <div className="buttons">
                     {
                         forceVerification && (

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -67,6 +67,8 @@ export function getScriptName(scriptType: ScriptType): string {
             return 'Segwit';
         case 'p2wpkh':
             return 'Native segwit (bech32)';
+        case 'p2tr':
+            return 'Taproot (bech32m)';
     }
 }
 


### PR DESCRIPTION
In the next design revamp the address type UI will probably be a
checkbox, keep changing address type as toggle until the revamp.

small drawback, the labels will probably not be "change to …" but rather just what it is "modern address..." 