### PR TITLE
ci: build iOS app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,37 @@ jobs:
         with:
           path: BitBoxApp-macos.zip
           name: BitBoxApp-macos-${{github.sha}}.zip
+  ios:
+    runs-on: macos-14
+    env:
+      GO_SRC_DIR: src/github.com/BitBoxSwiss/bitbox-wallet-app
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          # Take Go version to install from go.mod.
+          go-version-file: 'go.mod'
+      - name: Set GOPATH
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+      - name: Copy repo to GOPATH
+        # This is needed as gomobile is still unaware of go modules, so the repo must be in GOPATH
+        run: |
+          mkdir -p $GOPATH/$(dirname $GO_SRC_DIR)
+          cp -a ${{github.workspace}} $GOPATH/$(dirname $GO_SRC_DIR)
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install Qt
+        run: |
+          brew install qt@5
+          echo "/opt/homebrew/opt/qt@5/bin" >> $GITHUB_PATH
+      - name: Build iOS app
+        run: |
+          make gomobileinit
+          (cd $GOPATH/$GO_SRC_DIR; make ios)

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ envinit:
 	go install github.com/vektra/mockery/v2@latest
 	go install github.com/matryer/moq@latest
 	go install golang.org/x/tools/cmd/goimports@latest
+	$(MAKE) gomobileinit
+gomobileinit:
 	# TODO: replace with go install golang.org/x/mobile/cmd/gomobile@latest once https://github.com/golang/mobile/pull/105 is merged.
 	git clone https://github.com/BitBoxSwiss/mobile.git /tmp/mobile && cd /tmp/mobile/cmd/gomobile && go install .
 	gomobile init
@@ -74,6 +76,8 @@ qt-windows:
 android:
 	$(MAKE) buildweb
 	cd frontends/android && ${MAKE} apk-debug
+ios:
+	cd frontends/ios && ${MAKE} build
 osx-sec-check:
 	@echo "Checking build output"
 	./scripts/osx-build-check.sh

--- a/frontends/ios/Makefile
+++ b/frontends/ios/Makefile
@@ -6,3 +6,7 @@ prepare:
 	# Build Mobileserver.xcframework. No need to copy it, the xcode project references it
 	# directly from the mobileserver folder.
 	cd ../../backend/mobileserver && ${MAKE} build-ios
+# Build the app, unsigned. Useful for CI to check if the build succeeds.
+build:
+	${MAKE} prepare
+	xcodebuild clean build -project BitBoxApp/BitBoxApp.xcodeproj -scheme BitBoxApp -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
For now we ignore signing the app, publishing it or even running it. This first step is to simply compile the iOS app to check for build errors.

In the future, we may want to consider using github secrets to automatically sign and push to testflight.

The macos runner image is bumped to 14, which defaults to XCode
15. The older version had some build errors with the iOS app.

I also tried porting the macOS Qt job to run on macos-14 which runs on ARM, using scripts/osx-brew.sh to install the x84_64 version of Qt, which is needed so the app can be built for x84_64. It works but we postpone this until necessary, as it slows down CI a lot (emulates all of compilation in x86_64 on ARM).