### PR TITLE
frontend: update accounts list after keystore rename

### DIFF
--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -153,11 +153,11 @@ func (device *Device) SetOnEvent(onEvent func(deviceevent.Event, interface{})) {
 
 // SetDeviceName updates the device name and notifies keystore observers.
 func (device *Device) SetDeviceName(deviceName string) error {
-	if err := device.Device.SetDeviceName(deviceName); err != nil {
-		return err
-	}
 	rootFingerprint, err := device.keystore.RootFingerprint()
 	if err != nil {
+		return err
+	}
+	if err := device.Device.SetDeviceName(deviceName); err != nil {
 		return err
 	}
 	device.keystore.Notify(observable.Event{


### PR DESCRIPTION
SetDeviceName() can now report failure after the device name was already changed successfully. In device.go (line 155), the code first calls device.Device.SetDeviceName(deviceName) and only then fetches device.keystore.RootFingerprint() to build the NameChangedEvent. If that second step fails, handlers.go (line 145) returns an error response, and the UI treats the rename as failed in settings and setup flows (device-name-setting.tsx (line 41), wallet-create.tsx (line 63), wallet-restore.tsx (line 80)), even though the device itself already has the new name. The fingerprint lookup should happen before the rename, or the notification path should be best-effort so it cannot turn a successful rename into a failed API call.